### PR TITLE
diffusion map from CSR/laplacian modification to use new knn

### DIFF
--- a/data_structure/weighted_knn.py
+++ b/data_structure/weighted_knn.py
@@ -47,8 +47,11 @@ def weighted_knn(
     dr,
     k,
     metric="euclidean",
+    weighting="adaptive_gaussian",
     euclidean_as_similarity=False,
     epsilon=1e-12,
+    symmetrization="union",
+    sigma=None,
 ):
     """
     Build a weighted kNN graph.
@@ -60,30 +63,46 @@ def weighted_knn(
         Number of neighbors.
     metric : str
         "cosine" or "euclidean"
+    weighting : str or None
+        Edge weighting scheme.
+        Supported:
+            - None: default behavior
+                * cosine -> cosine similarity
+                * euclidean -> raw distance or inverse-distance depending on
+                  euclidean_as_similarity
+            - "raw"
+            - "inverse_distance"
+            - "gaussian"
+            - "adaptive_gaussian"
     euclidean_as_similarity : bool
-        Only used when metric="euclidean".
-        If False, store raw Euclidean distance as the edge weight.
-        If True, convert distance to similarity via 1 / (1 + distance + epsilon).
+        Backward-compatible option for euclidean metric when weighting=None.
     epsilon : float
         Small constant for numerical stability.
+    symmetrization : str
+        "union" or "mutual"
+    sigma : float or None
+        Global bandwidth for Gaussian kernel when weighting="gaussian".
+        If None, defaults to median directed kNN distance.
 
     Notes
     -----
-    - Neighbor selection:
+    Neighbor selection:
         * cosine: larger is better
         * euclidean: smaller distance is better
-    - Stored edge weights:
-        * cosine: cosine similarity
-        * euclidean:
-            - raw distance if euclidean_as_similarity=False
-            - inverse-distance similarity if euclidean_as_similarity=True
+
+    Symmetrization:
+        * union: keep edge if i->j or j->i exists
+        * mutual: keep edge only if both i->j and j->i exist
     """
     adjacency_matrix = similarities(
         dr,
         k,
         metric=metric,
+        weighting=weighting,
         euclidean_as_similarity=euclidean_as_similarity,
         epsilon=epsilon,
+        symmetrization=symmetrization,
+        sigma=sigma,
     )
     return graph_creation(adjacency_matrix, dr)
 
@@ -92,61 +111,175 @@ def similarities(
     dr,
     k,
     metric="cosine",
+    weighting=None,
     euclidean_as_similarity=False,
     epsilon=1e-12,
+    symmetrization="union",
+    sigma=None,
 ):
     n = dr.n
     data = np.array(dr.data, dtype=np.float32).reshape(n, dr.d)
 
-    adjacency_matrix = np.zeros((n, n), dtype=np.float32)
-
     if metric not in {"cosine", "euclidean"}:
         raise ValueError("metric must be 'cosine' or 'euclidean'")
 
+    if symmetrization not in {"union", "mutual"}:
+        raise ValueError("symmetrization must be 'union' or 'mutual'")
+
+    allowed_weighting = {None, "raw", "inverse_distance", "gaussian", "adaptive_gaussian"}
+    if weighting not in allowed_weighting:
+        raise ValueError(
+            "weighting must be one of None, 'raw', 'inverse_distance', "
+            "'gaussian', 'adaptive_gaussian'"
+        )
+
+    # -----------------------------
+    # 1) Compute full pairwise distances / similarities
+    # -----------------------------
+    dist_mat = np.zeros((n, n), dtype=np.float32)
+    sim_mat = np.zeros((n, n), dtype=np.float32)
+
     for i in range(n):
         row_i = data[i]
+        for j in range(i + 1, n):
+            row_j = data[j]
+
+            dist = euclidean_distance(row_i, row_j)
+            dist_mat[i, j] = dist
+            dist_mat[j, i] = dist
+
+            if metric == "cosine":
+                sim = cosine(row_i, row_j)
+                sim_mat[i, j] = sim
+                sim_mat[j, i] = sim
+
+    # -----------------------------
+    # 2) Build directed kNN graph
+    # -----------------------------
+    directed = np.zeros((n, n), dtype=np.float32)
+    kth_dist = np.zeros(n, dtype=np.float32)
+
+    for i in range(n):
         scores = []
 
         for j in range(n):
             if i == j:
                 continue
 
-            row_j = data[j]
-
             if metric == "cosine":
-                sim = cosine(row_i, row_j)
-                rank_score = sim          # larger is better
-                edge_weight = sim         # store cosine similarity
-
-            else:  # metric == "euclidean"
-                dist = euclidean_distance(row_i, row_j)
-                rank_score = -dist        # smaller distance is better
-
-                if euclidean_as_similarity:
-                    edge_weight = 1.0 / (1.0 + dist + epsilon)
-                else:
-                    edge_weight = dist
+                rank_score = sim_mat[i, j]   # larger is better
+            else:
+                rank_score = -dist_mat[i, j] # smaller is better
 
             scores.append(IndexScore(rank_score, j))
 
         heapq.heapify(scores)
 
+        nbrs = []
         for _ in range(min(k, len(scores))):
             item = heapq.heappop(scores)
-            j = item.index
+            nbrs.append(item.index)
+
+        if metric == "euclidean":
+            if len(nbrs) > 0:
+                kth_dist[i] = dist_mat[i, nbrs[-1]]
+            else:
+                kth_dist[i] = 0.0
+        elif metric == "cosine":
+            # needed only if adaptive_gaussian is requested with cosine, which we disallow below
+            kth_dist[i] = 0.0
+
+        for j in nbrs:
+            directed[i, j] = 1.0
+
+    # -----------------------------
+    # 3) Set default weighting behavior
+    # -----------------------------
+    if weighting is None:
+        if metric == "cosine":
+            weighting = "raw"
+        else:
+            weighting = "inverse_distance" if euclidean_as_similarity else "raw"
+
+    if weighting in {"gaussian", "adaptive_gaussian"} and metric != "euclidean":
+        raise ValueError("Gaussian weighting requires metric='euclidean'")
+
+    # Default global sigma if needed
+    if weighting == "gaussian" and sigma is None:
+        nonzero_kth = kth_dist[kth_dist > 0]
+        sigma = float(np.median(nonzero_kth)) if len(nonzero_kth) > 0 else 1.0
+
+    # -----------------------------
+    # 4) Assign directed edge weights
+    # -----------------------------
+    weighted_directed = np.zeros((n, n), dtype=np.float32)
+
+    for i in range(n):
+        for j in range(n):
+            if i == j or directed[i, j] == 0:
+                continue
 
             if metric == "cosine":
-                w = item.score
-            else:
-                # recompute edge weight from original distance
-                dist = euclidean_distance(row_i, data[j])
-                if euclidean_as_similarity:
-                    w = 1.0 / (1.0 + dist + epsilon)
+                # cosine-based weights
+                if weighting == "raw":
+                    w = sim_mat[i, j]
                 else:
+                    raise ValueError(
+                        f"weighting='{weighting}' not supported with metric='cosine'"
+                    )
+
+            else:
+                # euclidean-based weights
+                dist = dist_mat[i, j]
+
+                if weighting == "raw":
                     w = dist
 
-            adjacency_matrix[i][j] = w
-            adjacency_matrix[j][i] = w  # symmetric
+                elif weighting == "inverse_distance":
+                    w = 1.0 / (1.0 + dist + epsilon)
+
+                elif weighting == "gaussian":
+                    w = np.exp(-(dist ** 2) / (2.0 * (sigma ** 2) + epsilon))
+
+                elif weighting == "adaptive_gaussian":
+                    sig_i = kth_dist[i]
+                    sig_j = kth_dist[j]
+
+                    if sig_i <= 0 or sig_j <= 0:
+                        w = 0.0
+                    else:
+                        w = np.exp(-(dist ** 2) / (sig_i * sig_j + epsilon))
+
+                else:
+                    raise ValueError(f"Unknown weighting: {weighting}")
+
+            weighted_directed[i, j] = float(w)
+
+    # -----------------------------
+    # 5) Symmetrize
+    # -----------------------------
+    adjacency_matrix = np.zeros((n, n), dtype=np.float32)
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            wij = weighted_directed[i, j]
+            wji = weighted_directed[j, i]
+
+            if symmetrization == "union":
+                if wij != 0 or wji != 0:
+                    # average if both exist, otherwise keep the one present
+                    if wij != 0 and wji != 0:
+                        w = 0.5 * (wij + wji)
+                    else:
+                        w = wij if wij != 0 else wji
+                    adjacency_matrix[i, j] = w
+                    adjacency_matrix[j, i] = w
+
+            elif symmetrization == "mutual":
+                if wij != 0 and wji != 0:
+                    w = 0.5 * (wij + wji)
+                    adjacency_matrix[i, j] = w
+                    adjacency_matrix[j, i] = w
 
     return adjacency_matrix
 

--- a/trajectory_inference/Laplacian_Eigenmaps.py
+++ b/trajectory_inference/Laplacian_Eigenmaps.py
@@ -33,7 +33,7 @@ def loadAndCSR(adata, k):
     pca = adata.obsm["X_pca"]
     n, d = pca.shape
     dr = DenseRows(n = n, d = d, data = pca.flatten())
-    customCSR = weighted_knn(dr, k = k)
+    customCSR = weighted_knn(dr, k = k, metric='euclidean')
 
     # converting custom CSR to scipy sparse CSR
     CSR = sp.csr_matrix((customCSR.data, customCSR.indices, customCSR.indptr),shape=(n, n))
@@ -41,7 +41,7 @@ def loadAndCSR(adata, k):
     return CSR
 
 #### laplacian computation
-def laplacianEigenmaps(CSR, nComponents = 10):
+def laplacianEigenmaps(CSR, nComponents = 10,zero_tol=1e-10):
     """Input Parameters:
     CSR: compressed sparse row matrix of cell-cell similarity graph
     nComponents: number of embedding dimensions = 2 to get 2D embedding coordinates per cell required for circular pseudotime calculation
@@ -73,8 +73,10 @@ def laplacianEigenmaps(CSR, nComponents = 10):
     eigvecs = eigvecs[:,ordered]
 
     # dropping trivial eigenvector
-    embedding = eigvecs[:, 1:]
-    eigvals = eigvals[1:]
+    nontrivial = eigvals > zero_tol
+    eigvals = eigvals[nontrivial][1:]
+    embedding = eigvecs[:,nontrivial][:, 1:]
+
 
     return embedding, eigvals
 

--- a/trajectory_inference/diff_map.py
+++ b/trajectory_inference/diff_map.py
@@ -1,6 +1,0 @@
-# Diffusion Maps Implementation:
-# https://en.wikipedia.org/wiki/Diffusion_map
-
-
-
-    

--- a/trajectory_inference/diffusion_maps.py
+++ b/trajectory_inference/diffusion_maps.py
@@ -8,64 +8,122 @@ from scipy.sparse import diags
 import numpy as np
 from scipy.sparse.linalg import eigsh  # for symmetric conjugate matrix S
 
+import numpy as np
+import scipy.sparse as sp
+
+def custom_csr_to_scipy(C):
+    """
+    Convert custom CSR to scipy.sparse.csr_matrix.
+    """
+    return sp.csr_matrix(
+        (
+            np.asarray(C.data, dtype=float),
+            np.asarray(C.indices, dtype=int),
+            np.asarray(C.indptr, dtype=int),
+        ),
+        shape=(C.n, C.n),
+    )
 
 #### making ktilde
-def kTilde(adata, k):
 
-    X = adata.obsm["X_pca"]
+def kTilde(K, alpha=1.0, eps=1e-12):
+    """
+    Alpha-normalize an affinity matrix K.
 
-    N, d = X.shape
-    K = np.zeros((N,N))
+    Parameters
+    ----------
+    K : custom CSR or scipy.sparse matrix
+        Symmetric nonnegative affinity matrix.
+    alpha : float
+        Density-normalization exponent.
 
-    # building kNN graph to get neighbor indices
-    dr = DenseRows(n=N, d=d, data=X.flatten())
-    csr = weighted_knn(dr, k=k)
+    Returns
+    -------
+    K_tilde : scipy.sparse.csr_matrix
+        Alpha-normalized sparse matrix.
+    """
+    if hasattr(K, "indptr") and hasattr(K, "indices") and hasattr(K, "data") and hasattr(K, "n"):
+        K = custom_csr_to_scipy(K)
+    elif not sp.issparse(K):
+        K = sp.csr_matrix(K)
+    else:
+        K = K.tocsr()
 
-    # extracting (N x k) indices and Euclidean distances arrays from CSR
-    # weighten_knn.py CSR may have >k neighbors per cell due to symmetrization, so sorting by distance and taking k closest neighbors
-    indices = np.zeros((N, k), dtype=int)
-    distances = np.zeros((N, k))
-    for i in range(N):
-        nbrs = np.array(csr.indices[csr.indptr[i]:csr.indptr[i + 1]])
-        dists = np.linalg.norm(X[nbrs] - X[i], axis=1)
-        order = np.argsort(dists)[:k]
-        indices[i] = nbrs[order]
-        distances[i] = dists[order]
+    q = np.asarray(K.sum(axis=1)).ravel()
+    q = np.maximum(q, eps)
 
-    # adaptive heat kernel
-    alpha = 1.0
-    for i in range(len(indices)):
-        for j in range(k):
-            K[i,indices[i,j]] = np.exp(-distances[i,j]**2 /(distances[i,k-1]*distances[indices[i,j],k-1])) # adaptive kernel
-
-    K = (K+K.T)/2 # symmetrize
-
-    # density normalization
-    K_tilde = K.copy()
-    q = np.sum(K_tilde,axis=1)
     scale = q ** (-alpha)
-    K_tilde = (scale[:, None] * K) * scale[None, :]
+    D_alpha = diags(scale)
 
-    return K_tilde
+    K_tilde = D_alpha @ K @ D_alpha
+    return K_tilde.tocsr()
+
+# def kTilde(K, alpha=1.0):
+
+#     # X = adata.obsm["X_pca"]
+
+#     # N, d = X.shape
+#     # K = np.zeros((N,N))
+
+#     # # building kNN graph to get neighbor indices
+#     # dr = DenseRows(n=N, d=d, data=X.flatten())
+#     # csr = weighted_knn(dr, k=k,metric='euclidean')
+
+#     # # extracting (N x k) indices and Euclidean distances arrays from CSR
+#     # # weighten_knn.py CSR may have >k neighbors per cell due to symmetrization, so sorting by distance and taking k closest neighbors
+#     # indices = np.zeros((N, k), dtype=int)
+#     # distances = np.zeros((N, k))
+#     # for i in range(N):
+#     #     nbrs = np.array(csr.indices[csr.indptr[i]:csr.indptr[i + 1]])
+#     #     dists = np.linalg.norm(X[nbrs] - X[i], axis=1)
+#     #     order = np.argsort(dists)[:k]
+#     #     indices[i] = nbrs[order]
+#     #     distances[i] = dists[order]
+
+#     # # adaptive heat kernel
+#     # for i in range(len(indices)):
+#     #     for j in range(k):
+#     #         K[i,indices[i,j]] = np.exp(-distances[i,j]**2 /(distances[i,k-1]*distances[indices[i,j],k-1])) # adaptive kernel
+
+#     # K = (K+K.T)/2 # symmetrize
+
+#     # density normalization
+#     K_tilde = csr.copy()
+#     q = np.sum(K_tilde,axis=1)
+#     scale = q ** (-alpha)
+#     K_tilde = (scale[:, None] * K) * scale[None, :]
+
+#     return K_tilde
 
 #### getting embedding from ktilde
 def diffusion_map_from_Ktilde(K_tilde, n_components=30, t=1, eps=1e-12):
     """
-    K_tilde: symmetric sparse matrix after density normalization, before row-normalization
-    Returns:
-        emb:    (N, n_components) diffusion embedding
-        lambdas:(n_components,) nontrivial eigenvalues
-        psis:   (N, n_components) right eigenvectors of P
+    K_tilde: symmetric sparse matrix after alpha-normalization, before row-normalization
+
+    Returns
+    -------
+    emb : (N, n_components)
+        Diffusion embedding
+    lambdas : (n_components,)
+        Nontrivial eigenvalues
+    psis : (N, n_components)
+        Right eigenvectors of the Markov matrix P
     """
+    if not sp.issparse(K_tilde):
+        K_tilde = sp.csr_matrix(K_tilde)
+    else:
+        K_tilde = K_tilde.tocsr()
+
     d = np.asarray(K_tilde.sum(axis=1)).ravel()
     d = np.maximum(d, eps)
 
-    # symmetric conjugate S = D^{-1/2} K_tilde D^{-1/2}
     inv_sqrt_d = 1.0 / np.sqrt(d)
     D_inv_sqrt = diags(inv_sqrt_d)
-    S = D_inv_sqrt @ K_tilde @ D_inv_sqrt
 
-    # top eigenpairs
+    # symmetric conjugate
+    S = D_inv_sqrt @ K_tilde @ D_inv_sqrt
+    S = S.tocsr()
+
     vals, vecs = eigsh(S, k=n_components + 1, which="LA")
     order = np.argsort(-vals)
     vals = vals[order]
@@ -85,19 +143,10 @@ def diffusion_map_from_Ktilde(K_tilde, n_components=30, t=1, eps=1e-12):
 
 ##### finding pseudotime
 def diffusion_pseudotime(psis, lambdas, root=0, eps=1e-12):
-    """
-    psis:    (N, n_components)
-    lambdas: (n_components,)
-    root:    root cell index
-
-    Returns:
-        dpt: (N,) pseudotime/diffusion distance from root
-    """
-    denom = np.maximum(1.0 - lambdas, eps)  # avoid division by zero
-    diff = psis - psis[root, :]             # subtract root from every cell
+    denom = np.maximum(1.0 - lambdas, eps)
+    diff = psis - psis[root, :]
     dpt_sq = np.sum((diff ** 2) / denom[None, :], axis=1)
-    dpt = np.sqrt(dpt_sq)
-    return dpt
+    return np.sqrt(dpt_sq)
 
 #### finding root cell
 def findRootCell(adata, emb):
@@ -114,16 +163,31 @@ def findRootCell(adata, emb):
 
     return root
 
-#### full implementation of diffusion maps from adata
-def fullDiffusion(adata, k):
 
-    kt = kTilde(adata, k)
-    emb, lambdas, psis = diffusion_map_from_Ktilde(kt)
+def fullDiffusion(adata, k, alpha=1.0, n_components=30, t=1,
+                  weighting="adaptive_gaussian", symmetrization="union"):
+    """
+    Full diffusion maps pipeline using shared graph construction.
+    Assumes weighted_knn can build the affinity graph you want.
+    """
+    X = adata.obsm["X_pca"]
+    N, d = X.shape
+
+    dr = DenseRows(n=N, d=d, data=X.flatten())
+
+    K = weighted_knn(
+        dr,
+        k=k,
+        metric="euclidean",
+        weighting=weighting,
+        symmetrization=symmetrization,
+    )
+
+    K_tilde = kTilde(K, alpha=alpha)
+    emb, lambdas, psis = diffusion_map_from_Ktilde(K_tilde, n_components=n_components, t=t)
     root = findRootCell(adata, emb)
     dpt = diffusion_pseudotime(psis, lambdas, root=root)
 
     return emb, lambdas, psis, dpt
-
-
 
 


### PR DESCRIPTION
I've added different weighting schemes to the knn (including the adaptive gaussian kernel) so that we can isolate sources of differences between the laplacian eigenmaps and diffusion maps. also, diffusion maps now computes natively with a CSR, so it is much faster. In any case, the default weighting will be `adaptive_gaussian` for both methods going forward. 

Please let me know if you have any questions.